### PR TITLE
fixes- State dropdown not showing exact match

### DIFF
--- a/dist/js/selectWoo.full.js
+++ b/dist/js/selectWoo.full.js
@@ -4961,7 +4961,7 @@ S2.define('select2/defaults',[
       var term = stripDiacritics(params.term).toUpperCase();
 
       // Check if the text contains the term
-      if (original.indexOf(term) > -1) {
+      if ( original.indexOf(term) == 0 ) {
         return data;
       }
 


### PR DESCRIPTION
Fixes: State dropdown not showing exact match ref # https://github.com/woocommerce/woocommerce/pull/20605

As per suggestion PR done


This pull request includes a

- [ ] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

-
-
-

If this is related to an existing ticket, include a link to it as well.
