### PR TITLE
Fix jquery dependency in a11y sample docs

### DIFF
--- a/docs/accessibility-testing/samples/ajax.html
+++ b/docs/accessibility-testing/samples/ajax.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 

--- a/docs/accessibility-testing/samples/multi-ajax.html
+++ b/docs/accessibility-testing/samples/multi-ajax.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 

--- a/docs/accessibility-testing/samples/multi.html
+++ b/docs/accessibility-testing/samples/multi.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 

--- a/docs/accessibility-testing/samples/single-nesting.html
+++ b/docs/accessibility-testing/samples/single-nesting.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 

--- a/docs/accessibility-testing/samples/single-no-search.html
+++ b/docs/accessibility-testing/samples/single-no-search.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 

--- a/docs/accessibility-testing/samples/single-search.html
+++ b/docs/accessibility-testing/samples/single-search.html
@@ -3,7 +3,7 @@
 
     <link href="../select2.min.css" type="text/css" rel="stylesheet" />
 
-    <script type="text/javascript" src="../../vendor/js/jquery.min.js"></script>
+    <script type="text/javascript" src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
     <script type="text/javascript" src="../selectWoo.full.js"></script>
 </head>
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Grabs jQuery from the CDN rather than reference 404, which has broken the sample pages

Should resolve #22 
