### PR TITLE
Add optional aria-label to search inputs.

### DIFF
--- a/src/js/select2/dropdown/search.js
+++ b/src/js/select2/dropdown/search.js
@@ -18,6 +18,11 @@ define([
     this.$searchContainer = $search;
     this.$search = $search.find('input');
 
+    var label = this.options.get( 'label' );
+    if ( typeof( label ) === 'string' ) {
+      this.$search.attr( 'aria-label', label );
+    }
+
     $rendered.prepend($search);
 
     return $rendered;

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -19,6 +19,11 @@ define([
     this.$searchContainer = $search;
     this.$search = $search.find('input');
 
+    var label = this.options.get( 'label' );
+    if ( typeof( label ) === 'string' ) {
+      this.$search.attr( 'aria-label', label );
+    }
+
     var $rendered = decorated.call(this);
 
     this._transferTabIndex();


### PR DESCRIPTION
We had an accessibility auditor request that the input fields for
search style dropdowns include an aria-label. I've reused the option from #43
to keep things consistent.

This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made

- Adds an optional/configurable aria-label to search style inputs.

If this is related to an existing ticket, include a link to it as well.
This is related to #43 and extends that to work for search style inputs.