### PR TITLE
Various changes to get ARIA 1.1 compatibility.

### DIFF
--- a/src/js/select2/selection/base.js
+++ b/src/js/select2/selection/base.js
@@ -15,7 +15,7 @@ define([
   BaseSelection.prototype.render = function () {
     var $selection = $(
       '<span class="select2-selection" ' +
-      ' aria-haspopup="true" aria-expanded="false">' +
+      ' role="combobox" aria-haspopup="listbox" aria-expanded="false">' +
       '</span>'
     );
 
@@ -60,10 +60,6 @@ define([
       }
     });
 
-    container.on('results:focus', function (params) {
-      self.$selection.attr('aria-activedescendant', params.data._resultId);
-    });
-
     container.on('selection:update', function (params) {
       self.update(params.data);
     });
@@ -79,7 +75,6 @@ define([
     container.on('close', function () {
       // When the dropdown is closed, aria-expanded="false"
       self.$selection.attr('aria-expanded', 'false');
-      self.$selection.removeAttr('aria-activedescendant');
       self.$selection.removeAttr('aria-owns');
 
       // This needs to be delayed as the active element is the body when the

--- a/src/js/select2/selection/search.js
+++ b/src/js/select2/selection/search.js
@@ -12,7 +12,8 @@ define([
       '<li class="select2-search select2-search--inline">' +
         '<input class="select2-search__field" type="text" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
-        ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
+        ' spellcheck="false" role="textbox" aria-autocomplete="list"' +
+        ' aria-multiline="false" />' +
       '</li>'
     );
 
@@ -33,14 +34,14 @@ define([
     decorated.call(this, container, $container);
 
     container.on('open', function () {
-      self.$search.attr('aria-owns', resultsId);
+      self.$search.attr('aria-controls', resultsId);
       self.$search.trigger('focus');
     });
 
     container.on('close', function () {
       self.$search.val('');
       self.$search.removeAttr('aria-activedescendant');
-      self.$search.removeAttr('aria-owns');
+      self.$search.removeAttr('aria-controls');
       self.$search.trigger('focus');
     });
 


### PR DESCRIPTION
Add support for ARIA 1.1 per https://www.w3.org/TR/wai-aria-1.1/#combobox.

This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

The following changes were made
- "combobox" role attribute added to the wrapper
- "aria-haspopup" changed from "true" (which means "menu") to "listbox"
  to correctly match the role of the element containing the options
- "aria-activedescendant" removed from the combobox element so it
  appears just on the element with the "textbox" role
- "aria-multiline" set to "false" for the textbox element
- "aria-owns" switched to "aria-controls" on the textbox element