### PR TITLE
Fix - HTML escape for template selection

### DIFF
--- a/src/js/select2/selection/multiple.js
+++ b/src/js/select2/selection/multiple.js
@@ -126,7 +126,7 @@ define([
         formatted = Utils.entityDecode(formatted.trim());
       }
 
-      $selection.text(formatted);
+      $selection.append(formatted);
       $selection.prepend(removeItemTag);
       $selection.prop('title', selection.title || selection.text);
 

--- a/src/js/select2/selection/single.js
+++ b/src/js/select2/selection/single.js
@@ -111,7 +111,7 @@ define([
     var $rendered = this.$selection.find('.select2-selection__rendered');
     var formatted = Utils.entityDecode(this.display(selection, $rendered));
 
-    $rendered.empty().text(formatted);
+    $rendered.empty().append(formatted);
     $rendered.prop('title', selection.title || selection.text);
   };
 


### PR DESCRIPTION
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

The following changes were made

- Do not escape `templateSelection` argument have HTML.

If this is related to an existing ticket, include a link to it as well.
https://github.com/woocommerce/selectWoo/commit/b12317d5dcfd7da5f5c699db8fe2018eebc3b546#commitcomment-146694379

CC @barryhughes 
